### PR TITLE
Add Gnome 42 to version list

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "description": "A Gnome shell extension to use Yakuake on Gnome. Adds a global shortcut to show/hide yakuake and makes the console appear focussed.",
   "name": "Yakuake",
   "version": 4,
-  "shell-version": [ "40", "41" ],
+  "shell-version": [ "40", "41", "42" ],
   "url": "https://github.com/albertvaka/yakuake-gnome-extension",
   "uuid": "yakuake-extension@kde.org"
 }


### PR DESCRIPTION
Tested and works with GNOME Shell 42.0 on Ubuntu 22.04.