### PR TITLE
Fix _isYakuakeWindow falsely matching windows whose title contains 'Yakuake'

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -68,9 +68,12 @@ export default class YakuakeGnomeExtension extends Extension {
   _isYakuakeWindow(window) {
     if (!window) return false;
     const wmClass = window.get_wm_class();
-    if (wmClass && wmClass.toLowerCase() === 'yakuake') return true;
+    if (wmClass) {
+      const cls = wmClass.toLowerCase();
+      if (cls === 'yakuake' || cls === 'org.kde.yakuake') return true;
+    }
     const title = window.get_title();
-    if (title && title.includes('Yakuake')) return true;
+    if (title && title === 'Yakuake') return true;
     return false;
   }
 


### PR DESCRIPTION
Fixes #12

## Problem

`_isYakuakeWindow()` has two bugs that together cause any window (most commonly Firefox) to be mistaken for Yakuake if its title contains the word "Yakuake":

**1. wm_class check silently fails on native Wayland**

On a Wayland session, Mutter exposes Yakuake's window using its Wayland app-id (`org.kde.yakuake`) as the wm_class, not the short form `yakuake`. The existing check `wmClass.toLowerCase() === 'yakuake'` never matches, so execution always falls through to the title check.

**2. Title check uses a substring match**

```js
if (title && title.includes('Yakuake')) return true;
```

`window.get_title()` on a Firefox window returns its active tab title. If any tab has "Yakuake" in its title (a KDE bug report, a search result, this extension's own GitHub page), Firefox is falsely identified as Yakuake. The extension then calls `_moveToTop(firefoxWindow)` — moving Firefox to the top-center of the screen — and `Main.activateWindow(firefoxWindow)` — switching GNOME to Firefox's workspace, with Yakuake opening there too.

## Fix

```js
_isYakuakeWindow(window) {
  if (!window) return false;
  const wmClass = window.get_wm_class();
  if (wmClass) {
    const cls = wmClass.toLowerCase();
    if (cls === 'yakuake' || cls === 'org.kde.yakuake') return true;
  }
  const title = window.get_title();
  if (title && title === 'Yakuake') return true;
  return false;
}
```

- Adds `org.kde.yakuake` to the wm_class check (the Wayland app-id Mutter reports)
- Changes `title.includes('Yakuake')` → `title === 'Yakuake'` (exact match)

## Tested on

- Ubuntu 24.04, GNOME Shell 46, Wayland session
- Yakuake 23.08.5 (KDE Frameworks 5.115.0)
- Extension version 18